### PR TITLE
Raise error instead of only writing to log and returning empty set

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -44,7 +44,7 @@ def main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
     with open(var_file, "r") as stream:
         variable_config = yaml.load(stream, Loader=yaml.FullLoader)
 
-    # validate variables and against valid template
+    # validate variables and units against template
     illegal_vars, illegal_units = [], []
 
     for i, (var, unit) in df.variables(include_units=True).iterrows():
@@ -59,10 +59,6 @@ def main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
     if illegal_units:
         lst = [f"{v} - expected: {e}, found: {u}" for v, u, e in illegal_units]
         raise_error("units", lst)
-
-    # return empty IamDataFrame if illegal variables or units
-    if illegal_vars or illegal_units:
-        df.filter(model="", inplace=True)
 
     # remove unexpected meta columns
     expected_meta = list(ALLOWED_META) + ["exclude"]

--- a/workflow.py
+++ b/workflow.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 import logging
 import yaml
@@ -40,8 +39,7 @@ def main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
         raise_error("scenarios", illegal_scens)
 
     # load list of allowed variables
-    var_file = os.path.join(os.path.dirname(__file__), "variables.yml")
-    with open(var_file, "r") as stream:
+    with open(path / "variables.yml", "r") as stream:
         variable_config = yaml.load(stream, Loader=yaml.FullLoader)
 
     # validate variables and units against template


### PR DESCRIPTION
This PR changes the behavior of the workflow when encountering invalid scenarios, variables or units. Before, a message to the log was written and an empty IamDataFrame was returned (using `return df.filter(scenario="")`. The new implementation writes the error message to the log (as before) but then also raises a ValueError.

The advantage of the new implementation is that when the workflow is run as part of the Scenario-Explorer upload, the job will be marked red in the upload overview (instead of green).

fyi @peterkolp 