### PR TITLE
Add "World" to allowed regions

### DIFF
--- a/regions.yaml
+++ b/regions.yaml
@@ -4,6 +4,9 @@
 # Any changes to this file must also be migrated manually
 # to the IIASA Scenario Explorer by an IIASA admin before any data uploads.
 
+common:
+  World:
+
 Europäische Länder:
   Bulgarien:
     iso3: BGR


### PR DESCRIPTION
This PR adds "World" to the list of allowed regions. 

When working on this PR, I noticed two things:
 - this repository is not compatible with pyam v1.0 (released yesterday)
 - this repository (ie., `workflow.py`) does not actually validate that the submitted regions are in the list of allowed regions in the `regions.yaml` (the validation still happens on the database side)

I'll put these two items on my to-do list. Anyway, merging this PR clarifies what is happening on the database side and that the "World" region is now allowed.