### PR TITLE
Add (harmonized) focus scenario names

### DIFF
--- a/scenarios.yml
+++ b/scenarios.yml
@@ -23,3 +23,6 @@
 - CO2Price_Elec
 - CO2Price_H2
 - CO2Price_SynF
+- Focus_PV
+- Focus_Wind
+- Combination


### PR DESCRIPTION
This PR adds scenario names requested by the IEE team, but harmonized to English spelling and underscore instead of whitespace for consistency.