### PR TITLE
Quickfix for region-synonym-replacement

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -88,7 +88,7 @@ def _validate(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
     for region in definition.region.values():
         for synonym in ("abbr", "iso3"):
             if synonym in region.extra_attributes:
-                rename_dict[region.extra_attributes(synonym)] = region.name
+                rename_dict[region.extra_attributes[synonym]] = region.name
 
     df.rename(region=rename_dict, inplace=True)
 


### PR DESCRIPTION
Per a bug report by @fbenke-pik.

This PR fixes trying to call a **dict** instead of getting the attribute, introduced yesterday via #39.