### PR TITLE
Quick for configuration of illegal characters

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -3,4 +3,4 @@ dimensions:
   - variable
   - scenario
   - subannual
-illegal_characters: []
+illegal-characters: []


### PR DESCRIPTION
This is a quickfix for https://github.com/IAMconsortium/nomenclature/issues/506, to be reverted after the next nomenclature release.